### PR TITLE
feat: adicionar navegação para a página de cadastro de funcionário

### DIFF
--- a/web2dev/src/app/app.routes.ts
+++ b/web2dev/src/app/app.routes.ts
@@ -12,12 +12,14 @@ import { EfetuarorcamentoComponent } from './components/efetuarorcamento/efetuar
 import { FinalizarsolicitComponent } from './components/finalizarsolicit/finalizarsolicit.component';
 import { VisualizarsevicosComponent } from './components/visualizarsevicos/visualizarsevicos.component';
 import { PagarservicoComponent } from './components/pagarservico/pagarservico.component';
+import { CrudFuncionarioComponent } from './components/crud-funcionario/crud-funcionario.component';
 
 export const routes: Routes = [
     {'path': 'login', component:LoginComponent},
     {'path': 'pgcliente', component:PgClienteComponent},
     {'path': 'novasolicitacao', component:NovaSolicitacaoComponent},
     {'path': 'cadastro', component:CadastroComponent},
+    {'path': 'crud-funcionario', component:CrudFuncionarioComponent},
     {'path': 'pgfuncionario', component:PgFuncionarioComponent},
     {'path': 'orcamentocliente', component:OrcamentoclienteComponent},
     {'path': 'solicitabertas', component:SolicitabertafuncComponent},

--- a/web2dev/src/app/components/crud-funcionario/crud-funcionario.component.html
+++ b/web2dev/src/app/components/crud-funcionario/crud-funcionario.component.html
@@ -1,0 +1,1 @@
+<p>crud-funcionario works!</p>

--- a/web2dev/src/app/components/crud-funcionario/crud-funcionario.component.spec.ts
+++ b/web2dev/src/app/components/crud-funcionario/crud-funcionario.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CrudFuncionarioComponent } from './crud-funcionario.component';
+
+describe('CrudFuncionarioComponent', () => {
+  let component: CrudFuncionarioComponent;
+  let fixture: ComponentFixture<CrudFuncionarioComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CrudFuncionarioComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CrudFuncionarioComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web2dev/src/app/components/crud-funcionario/crud-funcionario.component.ts
+++ b/web2dev/src/app/components/crud-funcionario/crud-funcionario.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-crud-funcionario',
+  standalone: true,
+  imports: [],
+  templateUrl: './crud-funcionario.component.html',
+  styleUrl: './crud-funcionario.component.css'
+})
+export class CrudFuncionarioComponent {
+
+}

--- a/web2dev/src/app/components/login/login.component.html
+++ b/web2dev/src/app/components/login/login.component.html
@@ -18,6 +18,7 @@
                 Não tem cadastro? Cadastre-se
             </a>
             <a [routerLink]="['/pgfuncionario']">Entrar como funcionario</a>
+            <a [routerLink]="['/crud-funcionario']">Cadastrar funcionário</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- Configurada a rota para o componente crud-funcionario.
- Adicionado link "Cadastrar funcionário" na página de login.
- Implementado redirecionamento após a autenticação bem-sucedida.